### PR TITLE
Add missing imports

### DIFF
--- a/.github/workflows/prolog.yml
+++ b/.github/workflows/prolog.yml
@@ -5,6 +5,18 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install python requirements
+        run: pip install beautifulsoup4 requests
+        # Can be found on: https://github.com/terminusdb-labs/swipl-lint/
+      - name: Download script
+        run: curl -L 'https://raw.githubusercontent.com/terminusdb-labs/swipl-lint/v0.1/lint_modules.py' > lint_modules.py
+      - name: Run linter
+        run: python3 lint_modules.py
   build:
     runs-on: ubuntu-latest
 

--- a/prolog/tus.pl
+++ b/prolog/tus.pl
@@ -50,7 +50,13 @@
 :- use_module(tus/parse).
 :- use_module(tus/utilities).
 
+:- use_module(library(apply)).
 :- use_module(library(crypto)).
+:- use_module(library(debug)).
+:- use_module(library(error)).
+:- use_module(library(lists)).
+:- use_module(library(option)).
+:- use_module(library(readutil)).
 
 /* Options */
 :- meta_predicate valid_options(+, 1).

--- a/prolog/tus/utilities.pl
+++ b/prolog/tus/utilities.pl
@@ -3,6 +3,8 @@
               random_file/2
           ]).
 
+use_module(library(random)).
+
 /**
  * random_string(String) is det.
  */


### PR DESCRIPTION
Lint output that I fixed:

Predicate exclude used but not imported from library(apply) in file prolog/tus.pl
Predicate debug used but not imported from library(debug) in file prolog/tus.pl
Predicate must_be used but not imported from library(error) in file prolog/tus.pl
Predicate member used but not imported from library(lists) in file prolog/tus.pl
Predicate last used but not imported from library(lists) in file prolog/tus.pl
Predicate append used but not imported from library(lists) in file prolog/tus.pl
Predicate merge_options used but not imported from library(option) in file prolog/tus.pl
Predicate option used but not imported from library(option) in file prolog/tus.pl
Predicate read_file_to_string used but not imported from library(readutil) in file prolog/tus.pl
Predicate random used but not imported from library(random) in file prolog/tus/utilities.pl