### PR TITLE
Add content-length to patch request

### DIFF
--- a/prolog/tus.pl
+++ b/prolog/tus.pl
@@ -820,6 +820,7 @@ tus_patch_(Endpoint, File, Chunk, Position, Reply_Header, Tus_Options, Options) 
                          post(bytes('application/offset+octet-stream', String)),
                          request_header('Upload-Offset'=Position),
                          request_header('Tus-Resumable'='1.0.0'),
+                         request_header('Content-Length'=Chunk),
                          reply_header(Reply_Header),
                          status_code(Code)
                          |HdrExtra


### PR DESCRIPTION
Every request with a body in it should have a content-length as required by the HTTP standard.

We are assuming here that the chunk length is also the length of the content being send in bytes.