### PR TITLE
Content-length removed due to double headers issue

### DIFF
--- a/prolog/tus.pl
+++ b/prolog/tus.pl
@@ -821,7 +821,6 @@ tus_patch_(Endpoint, File, Chunk, Position, Reply_Header, Tus_Options, Options) 
                          post(bytes('application/offset+octet-stream', String)),
                          request_header('Upload-Offset'=Position),
                          request_header('Tus-Resumable'='1.0.0'),
-                         request_header('Content-Length'=Chunk),
                          reply_header(Reply_Header),
                          status_code(Code)
                          |HdrExtra


### PR DESCRIPTION
Recent changes in the swipl library seem to have added internal content-length support, whereas the tus protocol implementation added two additional content-length specifications that are now obsolete. The issues caused a double Content-length header which made tus violate header specifications and fail protocol validation of modern reverse proxies such as Nginx and Envoy.

By removing the Content-length specification from the tus library, the Content-length header is correctly added when necessary without adding the header manually.